### PR TITLE
Implement output size limit

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -69,10 +69,29 @@ func (c *ShellCommandConfig) UnmarshalJSON(data []byte) error {
 	c.AllowedDirectories = raw.AllowedDirectories
 	c.AllowCommands = allowCommands
 	c.DenyCommands = denyCommands
-	c.DefaultErrorMessage = raw.DefaultErrorMessage
+	
+	// Use default values if not specified
+	if raw.DefaultErrorMessage != "" {
+		c.DefaultErrorMessage = raw.DefaultErrorMessage
+	} else {
+		c.DefaultErrorMessage = "Command not allowed by security policy"
+	}
+	
 	c.BlockLogPath = raw.BlockLogPath
-	c.MaxExecutionTime = raw.MaxExecutionTime
-	c.MaxOutputSize = raw.MaxOutputSize
+	
+	// Use default execution time if not specified or invalid
+	if raw.MaxExecutionTime > 0 {
+		c.MaxExecutionTime = raw.MaxExecutionTime
+	} else {
+		c.MaxExecutionTime = DefaultExecutionTimeout
+	}
+	
+	// Use default output size if not specified or invalid
+	if raw.MaxOutputSize > 0 {
+		c.MaxOutputSize = raw.MaxOutputSize
+	} else {
+		c.MaxOutputSize = DefaultMaxOutputSize
+	}
 
 	return nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -69,23 +69,23 @@ func (c *ShellCommandConfig) UnmarshalJSON(data []byte) error {
 	c.AllowedDirectories = raw.AllowedDirectories
 	c.AllowCommands = allowCommands
 	c.DenyCommands = denyCommands
-	
+
 	// Use default values if not specified
 	if raw.DefaultErrorMessage != "" {
 		c.DefaultErrorMessage = raw.DefaultErrorMessage
 	} else {
 		c.DefaultErrorMessage = "Command not allowed by security policy"
 	}
-	
+
 	c.BlockLogPath = raw.BlockLogPath
-	
+
 	// Use default execution time if not specified or invalid
 	if raw.MaxExecutionTime > 0 {
 		c.MaxExecutionTime = raw.MaxExecutionTime
 	} else {
 		c.MaxExecutionTime = DefaultExecutionTimeout
 	}
-	
+
 	// Use default output size if not specified or invalid
 	if raw.MaxOutputSize > 0 {
 		c.MaxOutputSize = raw.MaxOutputSize

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,6 +9,9 @@ import (
 // Default execution timeout in seconds.
 const DefaultExecutionTimeout = 30
 
+// Default max output size in bytes (50KB).
+const DefaultMaxOutputSize = 50 * 1024
+
 // DenyCommand represents a command that is explicitly denied.
 type DenyCommand struct {
 	Command string `json:"command"`
@@ -31,6 +34,8 @@ type ShellCommandConfig struct {
 	BlockLogPath        string         `json:"blockLogPath,omitempty"`
 	// MaxExecutionTime is the maximum execution time in seconds
 	MaxExecutionTime int `json:"maxExecutionTime,omitempty"`
+	// MaxOutputSize is the maximum size of command output in bytes
+	MaxOutputSize int `json:"maxOutputSize,omitempty"`
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface for ShellCommandConfig.
@@ -42,6 +47,7 @@ func (c *ShellCommandConfig) UnmarshalJSON(data []byte) error {
 		DefaultErrorMessage string          `json:"defaultErrorMessage"`
 		BlockLogPath        string          `json:"blockLogPath,omitempty"`
 		MaxExecutionTime    int             `json:"maxExecutionTime,omitempty"`
+		MaxOutputSize       int             `json:"maxOutputSize,omitempty"`
 	}
 
 	if err := json.Unmarshal(data, &raw); err != nil {
@@ -66,6 +72,7 @@ func (c *ShellCommandConfig) UnmarshalJSON(data []byte) error {
 	c.DefaultErrorMessage = raw.DefaultErrorMessage
 	c.BlockLogPath = raw.BlockLogPath
 	c.MaxExecutionTime = raw.MaxExecutionTime
+	c.MaxOutputSize = raw.MaxOutputSize
 
 	return nil
 }
@@ -82,6 +89,7 @@ func NewDefaultConfig() *ShellCommandConfig {
 		DenyCommands:        []DenyCommand{{Command: "rm", Message: "Remove command is not allowed"}},
 		DefaultErrorMessage: "Command not allowed by security policy",
 		MaxExecutionTime:    DefaultExecutionTimeout,
+		MaxOutputSize:       DefaultMaxOutputSize,
 	}
 }
 

--- a/pkg/limiter/limiter.go
+++ b/pkg/limiter/limiter.go
@@ -1,0 +1,74 @@
+package limiter
+
+import (
+	"fmt"
+	"io"
+)
+
+// OutputLimiter wraps an io.Writer and limits the amount of data written.
+// It also keeps track of whether the output was truncated.
+type OutputLimiter struct {
+	Writer            io.Writer
+	MaxBytes          int
+	BytesWritten      int
+	Truncated         bool
+	TruncationMessage string
+}
+
+// NewOutputLimiter creates a new OutputLimiter.
+func NewOutputLimiter(writer io.Writer, maxBytes int) *OutputLimiter {
+	return &OutputLimiter{
+		Writer:            writer,
+		MaxBytes:          maxBytes,
+		BytesWritten:      0,
+		Truncated:         false,
+		TruncationMessage: fmt.Sprintf("\n\n[Output truncated, exceeded %d bytes limit]\n", maxBytes),
+	}
+}
+
+// Write implements the io.Writer interface.
+// It stops writing after MaxBytes and marks the output as truncated.
+func (ol *OutputLimiter) Write(p []byte) (n int, err error) {
+	// If we've already exceeded the limit, pretend we wrote all bytes
+	// but don't actually write anything
+	if ol.Truncated {
+		return len(p), nil
+	}
+
+	remaining := ol.MaxBytes - ol.BytesWritten
+	if remaining <= 0 {
+		// We've reached the limit but haven't marked as truncated yet
+		if !ol.Truncated {
+			// Write the truncation message
+			_, _ = ol.Writer.Write([]byte(ol.TruncationMessage))
+			ol.Truncated = true
+		}
+		return len(p), nil
+	}
+
+	var writeLen int
+	if len(p) > remaining {
+		// Write only up to the limit
+		writeLen = remaining
+		written, writeErr := ol.Writer.Write(p[:writeLen])
+		ol.BytesWritten += written
+		err = writeErr
+
+		// Mark as truncated and write the truncation message
+		ol.Truncated = true
+		_, _ = ol.Writer.Write([]byte(ol.TruncationMessage))
+
+		// Pretend we wrote all bytes to not confuse the caller
+		return len(p), err
+	}
+
+	// We can write all bytes
+	written, err := ol.Writer.Write(p)
+	ol.BytesWritten += written
+	return written, err
+}
+
+// WasTruncated returns whether the output was truncated.
+func (ol *OutputLimiter) WasTruncated() bool {
+	return ol.Truncated
+}

--- a/pkg/limiter/limiter.go
+++ b/pkg/limiter/limiter.go
@@ -90,6 +90,7 @@ func (ol *OutputLimiter) GetRemainingBytes() int {
 // the remaining output size.
 func (ol *OutputLimiter) getTruncationMessage() string {
 	remaining := ol.TotalInputBytes - ol.BytesWritten
-	return fmt.Sprintf("\n\n[Output truncated, exceeded %d bytes limit. %d bytes remaining]\n",
+	return fmt.Sprintf("\n\n[Output truncated, exceeded %d bytes limit. %d bytes remaining]\n"+
+		"If you need to view the complete output, consider using commands like tail or modifying your command to ensure the output stays within the limits.",
 		ol.MaxBytes, remaining)
 }

--- a/pkg/limiter/limiter_test.go
+++ b/pkg/limiter/limiter_test.go
@@ -56,7 +56,9 @@ func TestOutputLimiterBasic(t *testing.T) {
 		// Should contain 50 'a's + 50 'b's + truncation message
 		// Expected message now includes the remaining bytes info
 		expectedPrefix := string(toWrite1) + string(toWrite2[:50])
-		expected := expectedPrefix + fmt.Sprintf("\n\n[Output truncated, exceeded %d bytes limit. %d bytes remaining]\n", limiter.MaxBytes, 50)
+		expected := expectedPrefix + fmt.Sprintf("\n\n[Output truncated, exceeded %d bytes limit. %d bytes remaining]\n"+
+			"If you need to view the complete output, consider using commands like tail or modifying your command to ensure the output stays within the limits.",
+			limiter.MaxBytes, 50)
 		assert.Equal(t, expected, buf.String())
 	})
 

--- a/pkg/limiter/limiter_test.go
+++ b/pkg/limiter/limiter_test.go
@@ -2,13 +2,15 @@ package limiter
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/alecthomas/assert/v2"
 )
 
-func TestOutputLimiter(t *testing.T) {
+// TestOutputLimiterBasic tests basic writing functionality.
+func TestOutputLimiterBasic(t *testing.T) {
 	t.Run("Should write under limit", func(t *testing.T) {
 		buf := &bytes.Buffer{}
 		limiter := NewOutputLimiter(buf, 100)
@@ -52,7 +54,9 @@ func TestOutputLimiter(t *testing.T) {
 		assert.True(t, limiter.WasTruncated())
 
 		// Should contain 50 'a's + 50 'b's + truncation message
-		expected := string(toWrite1) + string(toWrite2[:50]) + limiter.TruncationMessage
+		// Expected message now includes the remaining bytes info
+		expectedPrefix := string(toWrite1) + string(toWrite2[:50])
+		expected := expectedPrefix + fmt.Sprintf("\n\n[Output truncated, exceeded %d bytes limit. %d bytes remaining]\n", limiter.MaxBytes, 50)
 		assert.Equal(t, expected, buf.String())
 	})
 
@@ -79,7 +83,10 @@ func TestOutputLimiter(t *testing.T) {
 		// Buffer should not have changed
 		assert.Equal(t, bufContent, buf.String())
 	})
+}
 
+// TestOutputLimiterEdgeCases tests edge cases like exact size matches.
+func TestOutputLimiterEdgeCases(t *testing.T) {
 	t.Run("Should handle exact size match", func(t *testing.T) {
 		buf := &bytes.Buffer{}
 		limiter := NewOutputLimiter(buf, 10)
@@ -102,5 +109,69 @@ func TestOutputLimiter(t *testing.T) {
 		assert.True(t, limiter.WasTruncated())
 		assert.True(t, strings.HasPrefix(buf.String(), string(toWrite)))
 		assert.True(t, strings.Contains(buf.String(), "truncated"))
+	})
+}
+
+// TestOutputLimiterRemainingBytes tests the remaining bytes functionality.
+func TestOutputLimiterRemainingBytes(t *testing.T) {
+	t.Run("Should track total input bytes and remaining bytes", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		limiter := NewOutputLimiter(buf, 100)
+
+		// First write under limit
+		toWrite1 := make([]byte, 60)
+		for i := range toWrite1 {
+			toWrite1[i] = 'a'
+		}
+
+		n1, err := limiter.Write(toWrite1)
+		assert.NoError(t, err)
+		assert.Equal(t, 60, n1)
+		assert.Equal(t, 60, limiter.TotalInputBytes)
+		assert.Equal(t, 0, limiter.GetRemainingBytes())
+
+		// Second write exceeding limit
+		toWrite2 := make([]byte, 80)
+		for i := range toWrite2 {
+			toWrite2[i] = 'b'
+		}
+
+		n2, err := limiter.Write(toWrite2)
+		assert.NoError(t, err)
+		assert.Equal(t, 80, n2)
+		assert.Equal(t, 140, limiter.TotalInputBytes) // 60 + 80
+		assert.True(t, limiter.WasTruncated())
+		assert.Equal(t, 40, limiter.GetRemainingBytes()) // 40 remaining bytes that couldn't be written
+
+		// Third write that should be ignored but still counted in total
+		toWrite3 := make([]byte, 50)
+		for i := range toWrite3 {
+			toWrite3[i] = 'c'
+		}
+
+		n3, err := limiter.Write(toWrite3)
+		assert.NoError(t, err)
+		assert.Equal(t, 50, n3)
+		assert.Equal(t, 190, limiter.TotalInputBytes)    // 60 + 80 + 50
+		assert.Equal(t, 90, limiter.GetRemainingBytes()) // 40 + 50 remaining bytes
+	})
+
+	t.Run("Should include remaining bytes in truncation message", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		limiter := NewOutputLimiter(buf, 20)
+
+		// Write enough to truncate
+		toWrite := make([]byte, 50)
+		for i := range toWrite {
+			toWrite[i] = 'a'
+		}
+
+		_, err := limiter.Write(toWrite)
+		assert.NoError(t, err)
+		assert.True(t, limiter.WasTruncated())
+
+		// Check that the truncation message contains the remaining bytes info
+		expectedMessage := "[Output truncated, exceeded 20 bytes limit. 30 bytes remaining]"
+		assert.True(t, strings.Contains(buf.String(), expectedMessage))
 	})
 }

--- a/pkg/limiter/limiter_test.go
+++ b/pkg/limiter/limiter_test.go
@@ -1,0 +1,106 @@
+package limiter
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+)
+
+func TestOutputLimiter(t *testing.T) {
+	t.Run("Should write under limit", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		limiter := NewOutputLimiter(buf, 100)
+
+		toWrite := make([]byte, 50)
+		for i := range toWrite {
+			toWrite[i] = 'a'
+		}
+
+		n, err := limiter.Write(toWrite)
+		assert.NoError(t, err)
+		assert.Equal(t, 50, n)
+		assert.Equal(t, 50, limiter.BytesWritten)
+		assert.False(t, limiter.WasTruncated())
+		assert.Equal(t, string(toWrite), buf.String())
+	})
+
+	t.Run("Should truncate at limit", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		limiter := NewOutputLimiter(buf, 100)
+
+		// First write under limit
+		toWrite1 := make([]byte, 50)
+		for i := range toWrite1 {
+			toWrite1[i] = 'a'
+		}
+
+		n1, err := limiter.Write(toWrite1)
+		assert.NoError(t, err)
+		assert.Equal(t, 50, n1)
+
+		// Second write exceeding limit
+		toWrite2 := make([]byte, 100)
+		for i := range toWrite2 {
+			toWrite2[i] = 'b'
+		}
+
+		n2, err := limiter.Write(toWrite2)
+		assert.NoError(t, err)
+		assert.Equal(t, 100, n2) // Reports full length even though truncated
+		assert.True(t, limiter.WasTruncated())
+
+		// Should contain 50 'a's + 50 'b's + truncation message
+		expected := string(toWrite1) + string(toWrite2[:50]) + limiter.TruncationMessage
+		assert.Equal(t, expected, buf.String())
+	})
+
+	t.Run("Should ignore writes after truncation", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		limiter := NewOutputLimiter(buf, 10)
+
+		// Write enough to truncate
+		toWrite1 := make([]byte, 20)
+		for i := range toWrite1 {
+			toWrite1[i] = 'a'
+		}
+
+		_, err := limiter.Write(toWrite1)
+		assert.NoError(t, err)
+		assert.True(t, limiter.WasTruncated())
+		bufContent := buf.String()
+
+		// Try writing more
+		toWrite2 := []byte("more data")
+		_, err = limiter.Write(toWrite2)
+		assert.NoError(t, err)
+
+		// Buffer should not have changed
+		assert.Equal(t, bufContent, buf.String())
+	})
+
+	t.Run("Should handle exact size match", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		limiter := NewOutputLimiter(buf, 10)
+
+		// Write exactly at the limit
+		toWrite := make([]byte, 10)
+		for i := range toWrite {
+			toWrite[i] = 'a'
+		}
+
+		n, err := limiter.Write(toWrite)
+		assert.NoError(t, err)
+		assert.Equal(t, 10, n)
+		assert.Equal(t, 10, limiter.BytesWritten)
+		assert.False(t, limiter.WasTruncated())
+
+		// Another write should be truncated
+		_, err = limiter.Write([]byte("more"))
+		assert.NoError(t, err)
+		assert.True(t, limiter.WasTruncated())
+		assert.True(t, strings.HasPrefix(buf.String(), string(toWrite)))
+		assert.True(t, strings.Contains(buf.String(), "truncated"))
+	})
+}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -80,6 +80,25 @@ func (r *SafeRunner) GetTruncationStatus() (stdoutTruncated bool, stderrTruncate
 	return
 }
 
+// GetTruncationDetails returns detailed information about truncation, including which
+// outputs were truncated and how many bytes remained unwritten for each.
+func (r *SafeRunner) GetTruncationDetails() (stdoutTruncated bool, stderrTruncated bool, stdoutRemainingBytes int, stderrRemainingBytes int) {
+	stdoutTruncated = r.stdoutLimiter != nil && r.stdoutLimiter.WasTruncated()
+	stderrTruncated = r.stderrLimiter != nil && r.stderrLimiter.WasTruncated()
+
+	stdoutRemainingBytes = 0
+	if stdoutTruncated {
+		stdoutRemainingBytes = r.stdoutLimiter.GetRemainingBytes()
+	}
+
+	stderrRemainingBytes = 0
+	if stderrTruncated {
+		stderrRemainingBytes = r.stderrLimiter.GetRemainingBytes()
+	}
+
+	return
+}
+
 // RunCommand runs a shell command in the specified working directory.
 // It enforces security constraints by validating commands and file access.
 func (r *SafeRunner) RunCommand(ctx context.Context, command string, workingDir string) error {

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -13,6 +13,7 @@ import (
 	"mvdan.cc/sh/v3/syntax"
 
 	"github.com/shimizu1995/secure-shell-server/pkg/config"
+	"github.com/shimizu1995/secure-shell-server/pkg/limiter"
 	"github.com/shimizu1995/secure-shell-server/pkg/logger"
 	"github.com/shimizu1995/secure-shell-server/pkg/validator"
 )
@@ -24,23 +25,59 @@ type SafeRunner struct {
 	logger    *logger.Logger
 	stdout    io.Writer
 	stderr    io.Writer
+	// Output limiters to track truncation
+	stdoutLimiter *limiter.OutputLimiter
+	stderrLimiter *limiter.OutputLimiter
 }
 
 // New creates a new SafeRunner.
 func New(config *config.ShellCommandConfig, validator *validator.CommandValidator, logger *logger.Logger) *SafeRunner {
 	return &SafeRunner{
-		config:    config,
-		validator: validator,
-		logger:    logger,
-		stdout:    os.Stdout,
-		stderr:    os.Stderr,
+		config:        config,
+		validator:     validator,
+		logger:        logger,
+		stdout:        os.Stdout,
+		stderr:        os.Stderr,
+		stdoutLimiter: nil,
+		stderrLimiter: nil,
 	}
 }
 
 // SetOutputs sets the stdout and stderr writers.
 func (r *SafeRunner) SetOutputs(stdout, stderr io.Writer) {
-	r.stdout = stdout
-	r.stderr = stderr
+	// If MaxOutputSize is set, wrap the writers with limiters
+	if r.config.MaxOutputSize > 0 {
+		r.stdoutLimiter = limiter.NewOutputLimiter(stdout, r.config.MaxOutputSize)
+		r.stderrLimiter = limiter.NewOutputLimiter(stderr, r.config.MaxOutputSize)
+		r.stdout = r.stdoutLimiter
+		r.stderr = r.stderrLimiter
+	} else {
+		// Use the writers directly if no limit is set
+		r.stdout = stdout
+		r.stderr = stderr
+		r.stdoutLimiter = nil
+		r.stderrLimiter = nil
+	}
+}
+
+// RunCommand runs a shell command in the specified working directory.
+// It enforces security constraints by validating commands and file access.
+// WasOutputTruncated returns whether stdout or stderr was truncated due to size limits.
+func (r *SafeRunner) WasOutputTruncated() bool {
+	if r.stdoutLimiter != nil && r.stdoutLimiter.WasTruncated() {
+		return true
+	}
+	if r.stderrLimiter != nil && r.stderrLimiter.WasTruncated() {
+		return true
+	}
+	return false
+}
+
+// GetTruncationStatus returns detailed information about which outputs were truncated.
+func (r *SafeRunner) GetTruncationStatus() (stdoutTruncated bool, stderrTruncated bool) {
+	stdoutTruncated = r.stdoutLimiter != nil && r.stdoutLimiter.WasTruncated()
+	stderrTruncated = r.stderrLimiter != nil && r.stderrLimiter.WasTruncated()
+	return
 }
 
 // RunCommand runs a shell command in the specified working directory.

--- a/pkg/validator/find_test.go
+++ b/pkg/validator/find_test.go
@@ -73,9 +73,9 @@ func testMultipleExecCommands(t *testing.T, parser *FindParser) {
 		{
 			name: "MultipleExecs",
 			args: []string{
-				"-type", "f", 
-				"-name", "*.txt", 
-				"-exec", "grep", "pattern", "{}", "\\;", 
+				"-type", "f",
+				"-name", "*.txt",
+				"-exec", "grep", "pattern", "{}", "\\;",
 				"-exec", "cp", "{}", "/backup/", "\\;",
 			},
 			wantCmds:   []string{"grep", "cp"},
@@ -85,8 +85,8 @@ func testMultipleExecCommands(t *testing.T, parser *FindParser) {
 		{
 			name: "MixedExecAndExecdir",
 			args: []string{
-				"-type", "f", 
-				"-exec", "ls", "-la", "{}", "\\;", 
+				"-type", "f",
+				"-exec", "ls", "-la", "{}", "\\;",
 				"-execdir", "chmod", "644", "{}", "\\;",
 			},
 			wantCmds:   []string{"ls", "chmod"},
@@ -161,10 +161,10 @@ func runFindParserTests(t *testing.T, parser *FindParser, tests []struct {
 	}
 }
 
-// TestFilterFindSpecialArgs tests the FilterFindSpecialArgs function
+// TestFilterFindSpecialArgs tests the FilterFindSpecialArgs function.
 func TestFilterFindSpecialArgs(t *testing.T) {
 	parser := NewFindParser()
-	
+
 	tests := []struct {
 		name     string
 		args     []string
@@ -177,7 +177,7 @@ func TestFilterFindSpecialArgs(t *testing.T) {
 		},
 		{
 			name:     "WithSemicolon",
-			args:     []string{"-name", "*.txt", "-exec", "echo", "{}" , ";"},
+			args:     []string{"-name", "*.txt", "-exec", "echo", "{}", ";"},
 			expected: []string{"-name", "*.txt", "-exec", "echo", "{}"},
 		},
 		{
@@ -201,7 +201,7 @@ func TestFilterFindSpecialArgs(t *testing.T) {
 			expected: []string{},
 		},
 	}
-	
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := parser.FilterFindSpecialArgs(tt.args)

--- a/sample-config.json
+++ b/sample-config.json
@@ -34,5 +34,6 @@
   ],
   "defaultErrorMessage": "This command is not allowed.",
   "blockLogPath": "/var/log/secure-shell/blocked-commands.log",
-  "maxExecutionTime": 60
+  "maxExecutionTime": 60,
+  "maxOutputSize": 51200
 }

--- a/service/server.go
+++ b/service/server.go
@@ -17,6 +17,22 @@ import (
 	"github.com/shimizu1995/secure-shell-server/pkg/validator"
 )
 
+// createRunCommandTool creates the common run_command tool with appropriate descriptions.
+func createRunCommandTool() mcp.Tool {
+	return mcp.NewTool("run_command",
+		mcp.WithDescription("Run shell commands in specific directories (only within allowed paths).\n"+
+			"The \"directory\" parameter sets the working directory automatically; \"cd\" command isn't needed."),
+		mcp.WithString("command",
+			mcp.Required(),
+			mcp.Description("Command to execute"),
+		),
+		mcp.WithString("directory",
+			mcp.Required(),
+			mcp.Description("Working directory to execute the command in."),
+		),
+	)
+}
+
 // Server is the MCP server for secure shell execution.
 type Server struct {
 	config    *config.ShellCommandConfig
@@ -60,17 +76,7 @@ func NewServer(cfg *config.ShellCommandConfig, port int, logPath string) (*Serve
 // Start initializes and starts the MCP server.
 func (s *Server) Start() error {
 	// Register the run_command tool
-	runCommandTool := mcp.NewTool("run_command",
-		mcp.WithDescription("Run shell commands in specific directories (only within allowed paths).\nThe \"directory\" parameter sets the working directory automatically; \"cd\" command isn't needed."),
-		mcp.WithString("command",
-			mcp.Required(),
-			mcp.Description("Command to execute"),
-		),
-		mcp.WithString("directory",
-			mcp.Required(),
-			mcp.Description("Working directory to execute the command in."),
-		),
-	)
+	runCommandTool := createRunCommandTool()
 
 	// Add the tool handler
 	s.mcpServer.AddTool(runCommandTool, s.handleRunCommand)
@@ -147,17 +153,7 @@ func (s *Server) handleRunCommand(ctx context.Context, request mcp.CallToolReque
 // ServeStdio starts an MCP server using stdin/stdout for communication.
 func (s *Server) ServeStdio() error {
 	// Register the run_command tool
-	runCommandTool := mcp.NewTool("run_command",
-		mcp.WithDescription("Run shell commands in specific directories (only within allowed paths).\nThe \"directory\" parameter sets the working directory automatically; \"cd\" command isn't needed."),
-		mcp.WithString("command",
-			mcp.Required(),
-			mcp.Description("Command to execute"),
-		),
-		mcp.WithString("directory",
-			mcp.Required(),
-			mcp.Description("Working directory to execute the command in."),
-		),
-	)
+	runCommandTool := createRunCommandTool()
 
 	// Add the tool handler
 	s.mcpServer.AddTool(runCommandTool, s.handleRunCommand)


### PR DESCRIPTION
This PR implements issue #13 - Adding output size limitation to prevent excessive output.

## Changes:

1. Added a new `MaxOutputSize` configuration parameter (with default of 50KB)
2. Created a new `limiter` package with `OutputLimiter` to wrap output writers and truncate them when they exceed the size limit
3. Modified the `SafeRunner` to use the output limiters when a size limit is set
4. Added helper methods to check if output was truncated
5. Updated sample-config.json to include the new parameter
6. Added unit tests for the new functionality

This feature helps prevent excessive output by truncating responses that exceed the configured size limit and informing the client that data has been truncated.

Resolves #13